### PR TITLE
Randomize tmp file name written to before rename

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "@alwaysai/tsconfig": "0.0.0",
     "@alwaysai/tslint-config": "0.0.3",
     "@types/jest": "24.0.18",
-    "@types/node": "12.7.8",
-    "fp-ts": "2.0.5",
+    "@types/node": "12.7.12",
+    "fp-ts": "2.1.0",
     "io-ts": "2.0.1",
     "jest": "24.9.0",
     "rimraf": "3.0.0",
@@ -45,7 +45,7 @@
     "ts-jest": "24.1.0",
     "ts-node": "8.4.1",
     "tslint": "5.20.0",
-    "typescript": "3.6.3"
+    "typescript": "3.6.4"
   },
   "files": [
     "src",

--- a/src/config-file.ts
+++ b/src/config-file.ts
@@ -17,6 +17,12 @@ function serialize(config: any) {
   return serialized;
 }
 
+function RandomString() {
+  return Math.random()
+    .toString(36)
+    .substring(2);
+}
+
 export function ConfigFile<T extends t.Mixed>(opts: {
   path: string;
   codec: T;
@@ -66,16 +72,16 @@ export function ConfigFile<T extends t.Mixed>(opts: {
       return info;
     }
     info.changed = true;
-    const tmpFilePath = `${path}.tmp`;
+    const tmpFilePath = `${path}.${RandomString()}.tmp`;
     mkdirp.sync(dirname(tmpFilePath));
     writeFileSync(tmpFilePath, serialized);
     try {
       renameSync(tmpFilePath, path);
-    } catch (ex) {
+    } catch (exception) {
       try {
         unlinkSync(tmpFilePath);
       } finally {
-        throw ex;
+        throw exception;
       }
     }
     return info;
@@ -139,7 +145,9 @@ export function ConfigFile<T extends t.Mixed>(opts: {
     const returnValue = updater(config);
     // This mutates the config object ^^
     if (typeof returnValue !== 'undefined') {
-      throw new Error('Updater returned a value. Mutate the passed config object!');
+      throw new Error(
+        'Updater returned a value. Mutate the passed configuration instead.',
+      );
     }
     const info = write(config);
     return info;


### PR DESCRIPTION
In the alwaysAI CLI, we see intermittent errors during unit tests of the form 
```
ENOENT: no such file or directory, rename '/Users/chrisarnesen/.config/alwaysai/alwaysai.credenti
als.json.tmp' -> '/Users/chrisarnesen/.config/alwaysai/alwaysai.credentials.json'
```
This can happen if the config file is being written to concurrently, which it's not really designed for. This PR should fix that error.