### PR TITLE
Add ConfigFileSchema which supports AJV JSON schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,10 @@
       "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
-        "@carnesen/coded-error": "0.4.0",
-        "@types/mkdirp": "1.0.2",
-        "mkdirp": "1.0.4"
+        "@carnesen/coded-error": "^0.4.0",
+        "@types/mkdirp": "^1.0.2",
+        "ajv": "^8.11.0",
+        "mkdirp": "^1.0.4"
       },
       "devDependencies": {
         "@alwaysai/codecs": "0.0.0",
@@ -1389,14 +1390,13 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
       },
       "funding": {
@@ -2825,8 +2825,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-diff": {
       "version": "1.2.0",
@@ -3179,6 +3178,28 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/har-validator/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/har-validator/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -4424,10 +4445,9 @@
       "dev": true
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/json-stable-stringify": {
       "version": "1.0.1",
@@ -5117,7 +5137,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -5241,6 +5260,14 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6355,7 +6382,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -7817,14 +7843,13 @@
       }
     },
     "ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
       }
     },
@@ -8929,8 +8954,7 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-diff": {
       "version": "1.2.0",
@@ -9216,6 +9240,26 @@
       "requires": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        }
       }
     },
     "has": {
@@ -10176,10 +10220,9 @@
       "dev": true
     },
     "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -10707,8 +10750,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.5.3",
@@ -10801,6 +10843,11 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "require-main-filename": {
       "version": "2.0.0",
@@ -11594,7 +11641,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -20,9 +20,10 @@
     "postversion": "npm publish"
   },
   "dependencies": {
-    "@carnesen/coded-error": "0.4.0",
-    "@types/mkdirp": "1.0.2",
-    "mkdirp": "1.0.4"
+    "@carnesen/coded-error": "^0.4.0",
+    "@types/mkdirp": "^1.0.2",
+    "ajv": "^8.11.0",
+    "mkdirp": "^1.0.4"
   },
   "peerDependencies": {
     "@alwaysai/codecs": "*",

--- a/src/config-file-schema.test.ts
+++ b/src/config-file-schema.test.ts
@@ -1,59 +1,67 @@
 import { chmodSync, existsSync, readFileSync, writeFileSync } from 'fs';
 import * as tempy from 'tempy';
-import * as t from 'io-ts';
 
-import { ConfigFile } from './config-file';
+import { ConfigFileSchema } from './config-file-schema';
 import { join } from 'path';
+import { JSONSchemaType } from 'ajv';
 
-const codec = t.intersection([
-  t.type({
-    foo: t.string,
-  }),
-  t.partial({ baz: t.string }),
-]);
+interface TestSchema {
+  foo: string;
+  baz?: string;
+}
+
+const schema: JSONSchemaType<TestSchema> = {
+  type: 'object',
+  properties: {
+    foo: { type: 'string' },
+    baz: { type: 'string', nullable: true },
+  },
+  required: ['foo'],
+  additionalProperties: false,
+};
 
 const path = tempy.file();
 
-const initialValue = {
+const initialValue: TestSchema = {
   foo: 'foo',
 };
 
-const subject = ConfigFile({
+const subject = ConfigFileSchema({
   path,
-  codec,
+  schema,
   initialValue,
 });
 
-describe(ConfigFile.name, () => {
+describe(ConfigFileSchema.name, () => {
   beforeEach(() => {
     subject.remove();
   });
 
-  it('"write" synchronously writes a file to the specified path', () => {
+  test('"write" synchronously writes a file to the specified path', () => {
     expect(existsSync(path)).toBe(false);
     subject.write({ foo: 'foo', baz: undefined });
     expect(existsSync(path)).toBe(true);
   });
 
-  it('"write" returns the file contents as "serialized"', () => {
+  test('"write" returns the file contents as "serialized"', () => {
     const info = subject.write({ foo: 'foo' });
     expect(info.serialized).toEqual(readFileSync(path, 'utf8'));
   });
 
-  it('"write" returns "changed" as `true` if it wrote the file, false otherwise', () => {
+  test('"write" returns "changed" as `true` if it wrote the file, false otherwise', () => {
     let info = subject.write({ foo: '123' });
     expect(info.changed).toEqual(true);
     info = subject.write({ foo: '123' });
     expect(info.changed).toEqual(false);
   });
 
-  it('"read" reads and parses as JSON the specified file path', () => {
+  test('"read" reads and parses as JSON the specified file path', () => {
     writeFileSync(path, '{"foo": "bar"}');
     const config = subject.read();
     expect(config).toEqual({ foo: 'bar' });
   });
 
-  it('"update" updates the contents of the file', () => {
+  test('"update" updates the contents of the file', () => {
     writeFileSync(path, '{"foo": "foo"}');
     subject.update((config) => {
       config.foo = 'bar';
@@ -61,29 +69,31 @@ describe(ConfigFile.name, () => {
     expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual({ foo: 'bar' });
   });
 
-  it('"update" uses the provided default config if the file does not exist', () => {
+  test('"update" uses the provided default config if the file does not exist', () => {
     subject.remove();
     subject.update(() => {});
     expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual(initialValue);
   });
 
-  it('"update" throws if the updater returns a value', () => {
+  test('"update" throws if the updater returns a value', () => {
     expect(() => subject.update(() => ({ foo: 'bar' }))).toThrow('Mutate');
   });
 
-  it('"update" throws if the there is no initial nor current value', () => {
+  test('"update" throws if the there is no initial nor current value', () => {
     expect(() =>
-      ConfigFile({ path: join(path, 'no-initial-value.json'), codec }).update(() => {}),
+      ConfigFileSchema({ path: join(path, 'no-initial-value.json'), schema }).update(
+        () => {},
+      ),
     ).toThrow('ENOENT');
   });
 
-  it('read/write sanity check', () => {
+  test('read/write sanity check', () => {
     const config = { foo: 'bar' };
     subject.write(config);
     expect(subject.read()).toEqual(config);
   });
 
-  it('initialize writes the file if it does not already exist', () => {
+  test('initialize writes the file if it does not already exist', () => {
     const config = { foo: 'bar' };
     subject.write(config);
     subject.initialize();
@@ -93,17 +103,40 @@ describe(ConfigFile.name, () => {
     expect(subject.read()).toEqual(initialValue);
   });
 
-  it('initialize throws if no initial value is provided', () => {
-    const configFile = ConfigFile({ path: join(path, 'no-initial-value-2.json'), codec });
+  test('errors are undefined if validation succeeds', () => {
+    const config = { foo: 'bar' };
+    subject.write(config);
+    expect(subject.getErrors()).toBe(null);
+  });
+
+  test('errors are provided when validation fails', () => {
+    writeFileSync(path, '{"bar": "bar"}');
+    expect(() => subject.read()).toThrow();
+    expect(subject.getErrors()).toEqual([
+      {
+        instancePath: '',
+        keyword: 'required',
+        message: "must have required property 'foo'",
+        params: { missingProperty: 'foo' },
+        schemaPath: '#/required',
+      },
+    ]);
+  });
+
+  test('initialize throws if no initial value is provided', () => {
+    const configFile = ConfigFileSchema({
+      path: join(path, 'no-initial-value-2.json'),
+      schema,
+    });
     expect(configFile.initialize).toThrow('initialValue');
   });
 
-  it('write throws EACCES', () => {
+  test('write throws EACCES', () => {
     const tmpDir = tempy.directory();
     chmodSync(tmpDir, 0o000);
-    const configFile = ConfigFile({
+    const configFile = ConfigFileSchema({
       path: join(tmpDir, 'test.json'),
-      codec,
+      schema,
       initialValue,
       EACCES: { code: 'foo', message: 'bar' },
     });
@@ -111,20 +144,20 @@ describe(ConfigFile.name, () => {
     chmodSync(tmpDir, 0o777);
   });
 
-  it('read throws ENOENT', () => {
-    const configFile = ConfigFile({
+  test('read throws ENOENT', () => {
+    const configFile = ConfigFileSchema({
       path: tempy.file(),
-      codec,
+      schema,
       ENOENT: { code: 'foo', message: 'bar' },
     });
     expect(() => configFile.read()).toThrow('bar');
   });
 
-  it('read throws EACCES', () => {
+  test('read throws EACCES', () => {
     const tmpPath = tempy.file();
-    const configFile = ConfigFile({
+    const configFile = ConfigFileSchema({
       path: tmpPath,
-      codec,
+      schema,
       initialValue,
       EACCES: { code: 'foo', message: 'bar' },
     });

--- a/src/config-file-schema.ts
+++ b/src/config-file-schema.ts
@@ -1,0 +1,192 @@
+import { dirname, resolve } from 'path';
+import { readFileSync, writeFileSync, renameSync, unlinkSync, existsSync } from 'fs';
+import { CodedError } from '@carnesen/coded-error';
+import mkdirp = require('mkdirp');
+import Ajv, { JSONSchemaType } from 'ajv';
+
+const ajv = new Ajv();
+
+function parse(serialized: string) {
+  const parsed: any = JSON.parse(serialized);
+  return parsed;
+}
+
+function serialize(config: any) {
+  const serialized = `${JSON.stringify(config, null, 2)}\n`;
+  return serialized;
+}
+
+function RandomString() {
+  return Math.random().toString(36).substring(2);
+}
+
+function isErrnoException(error: any): error is NodeJS.ErrnoException {
+  return (
+    Object.prototype.hasOwnProperty.call(error, 'code') ||
+    Object.prototype.hasOwnProperty.call(error, 'errno')
+  );
+}
+
+export function ConfigFileSchema<T>(opts: {
+  path: string;
+  schema: JSONSchemaType<T>;
+  ENOENT?: {
+    message?: string;
+    code?: any;
+  };
+  EACCES?: {
+    message?: string;
+    code?: any;
+  };
+  initialValue?: T;
+}) {
+  const path = resolve(opts.path);
+  type Config = T;
+  const validate = ajv.compile(opts.schema);
+
+  return {
+    path,
+    read,
+    readIfExists,
+    readRaw,
+    readParsed,
+    write,
+    writeRaw,
+    remove,
+    update,
+    exists,
+    initialize,
+    getErrors,
+  };
+
+  function readRaw() {
+    let serialized: string;
+    try {
+      serialized = readFileSync(path, { encoding: 'utf8' });
+    } catch (ex) {
+      if (isErrnoException(ex)) {
+        if (ex.code === 'ENOENT' && opts.ENOENT) {
+          const message = opts.ENOENT.message || ex.message || 'File not found';
+          const code = opts.ENOENT.code || 'ENOENT';
+          throw new CodedError(message, code);
+        } else if (ex.code === 'EACCES' && opts.EACCES) {
+          const message =
+            opts.EACCES.message || ex.message || 'Permission not granted on file';
+          const code = opts.EACCES.code || 'EACCES';
+          throw new CodedError(message, code);
+        }
+      }
+      throw ex;
+    }
+    return serialized;
+  }
+
+  function writeRaw(serialized: string) {
+    const info = {
+      changed: false,
+    };
+    if (existsSync(path) && serialized === readRaw()) {
+      return info;
+    }
+    info.changed = true;
+    const tmpFilePath = `${path}.${RandomString()}.tmp`;
+    try {
+      mkdirp.sync(dirname(tmpFilePath));
+      writeFileSync(tmpFilePath, serialized);
+    } catch (ex) {
+      if (isErrnoException(ex)) {
+        if (ex.code === 'EACCES' && opts.EACCES) {
+          const message =
+            opts.EACCES.message || ex.message || 'Permission not granted on file';
+          const code = opts.EACCES.code || 'EACCES';
+          throw new CodedError(message, code);
+        }
+      }
+      throw ex;
+    }
+    try {
+      renameSync(tmpFilePath, path);
+    } catch (exception) {
+      try {
+        unlinkSync(tmpFilePath);
+      } finally {
+        throw exception;
+      }
+    }
+    return info;
+  }
+
+  function readParsed() {
+    const serialized = readRaw();
+    const parsed = parse(serialized);
+    return parsed;
+  }
+
+  function read() {
+    const parsed = readParsed();
+    if (!validate(parsed)) {
+      throw new Error(`Validation of ${path} failed!`);
+    }
+    return parsed as Config;
+  }
+
+  function exists() {
+    return existsSync(path);
+  }
+
+  function readIfExists() {
+    const maybeConfig: Config | undefined = exists() ? read() : undefined;
+    return maybeConfig;
+  }
+
+  function write(config: Config) {
+    if (!validate(config)) {
+      throw new Error(`Validation of ${config} failed!`);
+    }
+    const serialized = serialize(config);
+    const info = writeRaw(serialized);
+    return { ...info, serialized };
+  }
+
+  function remove() {
+    const value = {
+      changed: false,
+    };
+    if (existsSync(path)) {
+      value.changed = true;
+      unlinkSync(path);
+    }
+    return value;
+  }
+
+  function initialize() {
+    if (typeof opts.initialValue === 'undefined') {
+      throw new Error('"initialize" can only be called if "initialValue" is provided');
+    }
+    if (!exists()) {
+      write(opts.initialValue);
+    }
+  }
+
+  function update(updater: (config: Config) => void) {
+    let config: Config;
+    if (opts.initialValue) {
+      config = readIfExists() || opts.initialValue;
+    } else {
+      config = read();
+    }
+    const returnValue = updater(config);
+    // This mutates the config object ^^
+    if (typeof returnValue !== 'undefined') {
+      throw new Error(
+        'Updater returned a value. Mutate the passed configuration instead.',
+      );
+    }
+    const info = write(config);
+    return info;
+  }
+
+  function getErrors() {
+    return validate.errors;
+  }
+}

--- a/src/config-file-schema.ts
+++ b/src/config-file-schema.ts
@@ -56,6 +56,7 @@ export function ConfigFileSchema<T>(opts: {
     update,
     exists,
     initialize,
+    validate,
     getErrors,
   };
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,0 @@
-import { homedir } from 'os';
-import { join } from 'path';
-
-export const ALWAYSAI_CONFIG_DIR = join(homedir(), '.config', 'alwaysai');

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,9 +1,8 @@
-import { ALWAYSAI_CONFIG_DIR, ConfigFile } from './index';
-const pkg = require('../package');
+import { ConfigFile, ConfigFileSchema } from './index';
 
-describe(pkg.name, () => {
-  it(`exports a constructor function ${ConfigFile.name} and a string constant ALWAYSAI_CONFIG_DIR`, () => {
+describe('index', () => {
+  test(`check exports`, () => {
     expect(typeof ConfigFile).toBe('function');
-    expect(typeof ALWAYSAI_CONFIG_DIR).toBe('string');
+    expect(typeof ConfigFileSchema).toBe('function');
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { ALWAYSAI_CONFIG_DIR } from './constants';
 export { ConfigFile } from './config-file';
+export { ConfigFileSchema } from './config-file-schema';


### PR DESCRIPTION
This change adds a new config file called `ConfigFileSchema`. The intention is to eventually replace the old JSON schema but it would be significantly disruptive to do that all at once. The errors for JSON schema validation are much more user-friendly. I'll add a comment on the unit test that shows an example error. For reference, `io-ts` basically gives you a type error which becomes unwieldy when the types get large.