### PR TITLE
Add error handling to parse and readParsed

### DIFF
--- a/src/config-file-schema.test.ts
+++ b/src/config-file-schema.test.ts
@@ -181,33 +181,35 @@ describe(ConfigFileSchema.name, () => {
     expect(() => testConfig.readParsed()).toThrow();
   });
 
-  test('read of invalid JSON (extra comma) throws default error when JSONDecodeError provided with no message', () => {
+  test('read of invalid JSON (extra comma) throws default error when parseError provided with no message', () => {
     writeFileSync(path, '{"foo": [1,2,]}');
-    const testConfig = ConfigFileSchema({ path, validateFunction, JSONDecodeError: {} });
-    expect(() => testConfig.read()).toThrow(
-      `Contents of ${path} could not be parsed. Please ensure file is in valid JSON format.`,
+    const testConfig = ConfigFileSchema({ path, validateFunction, parseError: {} });
+    expect(() => testConfig.read()).toThrowError(
+      `Contents of ${path} could not be parsed. Please ensure file is in a valid format. \nUnexpected token ] in JSON at position 13`,
     );
   });
 
-  test('read of invalid JSON (missing end brace) throws default error when JSONDecodeError provided with no message', () => {
+  test('read of invalid JSON (missing end brace) throws default error when parseError provided with no message', () => {
     writeFileSync(path, '{"foo": [1,2,]');
-    const testConfig = ConfigFileSchema({ path, validateFunction, JSONDecodeError: {} });
-    expect(() => testConfig.read()).toThrow(
-      `Contents of ${path} could not be parsed. Please ensure file is in valid JSON format.`,
+    const testConfig = ConfigFileSchema({ path, validateFunction, parseError: {} });
+    expect(() => testConfig.read()).toThrowError(
+      `Contents of ${path} could not be parsed. Please ensure file is in a valid format. \nUnexpected token ] in JSON at position 13`,
     );
   });
 
-  test('read of invalid JSON throws custome error when JSONDecodeError provided with message', () => {
+  test('read of invalid JSON throws custome error when parseError provided with message', () => {
     writeFileSync(path, '{"foo": [1,2,]}');
     const testConfig = ConfigFileSchema({
       path,
       validateFunction,
-      JSONDecodeError: { message: 'NOT ABLE TO PARSE' },
+      parseError: { message: 'NOT ABLE TO PARSE' },
     });
-    expect(() => testConfig.read()).toThrow('NOT ABLE TO PARSE');
+    expect(() => {
+      testConfig.read();
+    }).toThrowError('NOT ABLE TO PARSE\nUnexpected token ] in JSON at position 13');
   });
 
-  test('read of invalid JSON throws original error when JSONDecodeError not provided', () => {
+  test('read of invalid JSON throws original error when parseError not provided', () => {
     writeFileSync(path, '{"foo": [1,2,]}');
     const testConfig = ConfigFileSchema({ path, validateFunction });
     expect(() => testConfig.read()).toThrowError(SyntaxError);

--- a/src/config-file-schema.test.ts
+++ b/src/config-file-schema.test.ts
@@ -174,4 +174,17 @@ describe(ConfigFileSchema.name, () => {
     expect(() => configFile.read()).toThrow('bar');
     chmodSync(tmpPath, 0o777);
   });
+
+  test('readParsed of invalid JSON returns undefined', () => {
+    writeFileSync(path, '{"foo": "bar"');
+    const testConfig = ConfigFileSchema({ path, validateFunction });
+    const parsedConfig = testConfig.readParsed();
+    expect(parsedConfig).toEqual(undefined);
+  });
+
+  test('read of invalid JSON throws error', () => {
+    writeFileSync(path, '{"foo": "bar"');
+    const testConfig = ConfigFileSchema({ path, validateFunction });
+    expect(() => testConfig.read()).toThrow(`Validation of ${path} failed!`);
+  });
 });

--- a/src/config-file-schema.ts
+++ b/src/config-file-schema.ts
@@ -122,8 +122,8 @@ export function ConfigFileSchema<T>(opts: {
   }
 
   function readParsed() {
+    const serialized = readRaw();
     try {
-      const serialized = readRaw();
       const parsed = parse(serialized);
       return parsed;
     } catch (error) {

--- a/src/config-file-schema.ts
+++ b/src/config-file-schema.ts
@@ -36,7 +36,7 @@ export function ConfigFileSchema<T>(opts: {
     message?: string;
     code?: any;
   };
-  JSONDecodeError?: {
+  parseError?: {
     message?: string;
     code?: any;
   };
@@ -126,11 +126,11 @@ export function ConfigFileSchema<T>(opts: {
       return parsed;
     } catch (ex: any) {
       if (ex instanceof SyntaxError) {
-        if (opts.JSONDecodeError) {
+        if (opts.parseError) {
           const message =
-            opts.JSONDecodeError.message ||
-            `Contents of ${path} could not be parsed. Please ensure file is in valid JSON format.`;
-          const code = opts.JSONDecodeError.code || 'JSONDecodeError';
+            opts.parseError.message?.concat(`\n${ex.message}`) ||
+            `Contents of ${path} could not be parsed. Please ensure file is in a valid format. \n${ex.message}`;
+          const code = opts.parseError.code || 'parseError';
           throw new CodedError(message, code);
         }
       }

--- a/src/config-file-schema.ts
+++ b/src/config-file-schema.ts
@@ -125,12 +125,13 @@ export function ConfigFileSchema<T>(opts: {
       const parsed = parse(serialized);
       return parsed;
     } catch (ex: any) {
-      if (ex instanceof(SyntaxError)) {
+      if (ex instanceof SyntaxError) {
         if (opts.JSONDecodeError) {
           const message =
-              opts.JSONDecodeError.message || `Contents of ${path} could not be parsed. Please ensure file is in valid JSON format.`;
-            const code = opts.JSONDecodeError.code || 'JSONDecodeError';
-            throw new CodedError(message, code);
+            opts.JSONDecodeError.message ||
+            `Contents of ${path} could not be parsed. Please ensure file is in valid JSON format.`;
+          const code = opts.JSONDecodeError.code || 'JSONDecodeError';
+          throw new CodedError(message, code);
         }
       }
       throw ex;

--- a/src/config-file-schema.ts
+++ b/src/config-file-schema.ts
@@ -5,8 +5,14 @@ import mkdirp = require('mkdirp');
 import { ValidateFunction } from 'ajv';
 
 function parse(serialized: string) {
-  const parsed: any = JSON.parse(serialized);
-  return parsed;
+  try {
+    const parsed: any = JSON.parse(serialized);
+    return parsed;
+  } catch (error) {
+    throw new Error(
+      'Error parsing file contents into valid JSON. Please check file is properly formatted.',
+    );
+  }
 }
 
 function serialize(config: any) {
@@ -116,9 +122,13 @@ export function ConfigFileSchema<T>(opts: {
   }
 
   function readParsed() {
-    const serialized = readRaw();
-    const parsed = parse(serialized);
-    return parsed;
+    try {
+      const serialized = readRaw();
+      const parsed = parse(serialized);
+      return parsed;
+    } catch (error) {
+      return undefined;
+    }
   }
 
   function read() {


### PR DESCRIPTION
These changes cause `undefined` to be returned by `readParsed()` in the event that the json file is not able to be read (`json.parse()` fails). When `undefined` is returned by `readParsed()`, `read` will call `validate` with `undefined`, which cases validate.errors to be populated properly, and then downstream packages are able to print out messages accordingly.

With this change, running `aai model validate-package` on a corrupted JSON file causes the following to be displayed:

`Validating the model package file...
⚠ Could not validate the configuration. Possible issues with the configuration file fields: 

✖  must be object`

And the following is logged to the log files:
`error: [
  {
    "instancePath": "",
    "schemaPath": "#/type",
    "keyword": "type",
    "params": {
      "type": "object"
    },
    "message": "must be object"
  }
]`